### PR TITLE
Fix Resize

### DIFF
--- a/transforms.py
+++ b/transforms.py
@@ -67,7 +67,7 @@ def classification_simple_pipeline_builder(*, input_type, api_version):
     pipeline.extend(
         [
             RandomResizedCropWithoutResize(224),
-            transforms.Resize(224, antialias=True),
+            transforms.Resize((224, 224), antialias=True),
             transforms.RandomHorizontalFlip(p=0.5),
         ]
     )
@@ -111,7 +111,7 @@ def classification_complex_pipeline_builder(*, input_type, api_version):
     pipeline.extend(
         [
             RandomResizedCropWithoutResize(224),
-            transforms.Resize(224, antialias=True),
+            transforms.Resize((224, 224), antialias=True),
             transforms.RandomHorizontalFlip(p=0.5),
             transforms.AutoAugment(transforms.AutoAugmentPolicy.IMAGENET),
         ]


### PR DESCRIPTION
`Resize(224)` will set the smallest edge to 224, instead of setting the output shape to `(224, 224)` which is what we want (and that's what `RandomResizedCrop(224)` does - go figure).

CC @vfdev-5 :)

![image](https://github.com/pmeier/detection-reference-benchmark/assets/1190450/704fcaba-4e12-4203-9dbd-9adbed303ff4)
